### PR TITLE
Allow alternative baud rates on OS X

### DIFF
--- a/juce_serialport.h
+++ b/juce_serialport.h
@@ -190,7 +190,7 @@ public:
 		const juce::ScopedLock l(bufferCriticalSection);
 		return bufferedbytes?false:true;
 	};
-	virtual juce::int64 getPosition(){return -1;}
+	virtual juce::int64 getPosition(){return 0;}
 	virtual bool setPosition(juce::int64 /*newPosition*/){return false;}
     virtual void cancel ();
     SerialPort* getPort() { return port; }

--- a/juce_serialport.h
+++ b/juce_serialport.h
@@ -109,7 +109,7 @@ public:
 		open(portPath);
 		setConfig(config);
 	}
-	~SerialPort()
+	virtual ~SerialPort()
 	{
 		close();
 	}

--- a/juce_serialport_OSX.cpp
+++ b/juce_serialport_OSX.cpp
@@ -245,8 +245,7 @@ void SerialPortInputStream::run()
 	while(port && (port->portDescriptor!=-1) && !threadShouldExit())
 	{
 		unsigned char c;
-		int bytesread=0;
-		bytesread = ::read(port->portDescriptor, &c, 1);
+		const auto bytesread = ::read(port->portDescriptor, &c, 1);
 		if(bytesread==1)
 		{
 			const ScopedLock l(bufferCriticalSection);
@@ -293,12 +292,11 @@ void SerialPortOutputStream::run()
 			triggerWrite.wait(100);
 		if(bufferedbytes)
 		{
-			int byteswritten=0;
 			bufferCriticalSection.enter();
 			int bytestowrite=bufferedbytes>writeBufferSize?writeBufferSize:bufferedbytes;
 			memcpy(tempbuffer, buffer.getData(), bytestowrite);
 			bufferCriticalSection.exit();
-			byteswritten = ::write(port->portDescriptor, tempbuffer, bytestowrite);
+			const auto byteswritten = ::write(port->portDescriptor, tempbuffer, bytestowrite);
 			if(byteswritten>0)
 			{
 				const ScopedLock l(bufferCriticalSection);

--- a/juce_serialport_OSX.cpp
+++ b/juce_serialport_OSX.cpp
@@ -9,6 +9,8 @@
 
 #if JUCE_MAC
 
+using namespace juce;
+
 #define Point DUMMY_Point
 #define Component DUMMY_Component
 #include <stdio.h>

--- a/juce_serialport_OSX.cpp
+++ b/juce_serialport_OSX.cpp
@@ -141,7 +141,8 @@ bool SerialPort::setConfig(const SerialPortConfig & config)
 	options.c_cflag |= CREAD; //enable reciever (daft)
 	options.c_cflag |= CLOCAL;//don't monitor modem control lines
 	//baud and bits
-	cfsetspeed(&options, config.bps);
+    cfsetspeed(&options, 9600); //Just set 9600 to get this to pass,
+                                //we'll set the actual baud rate later
 	switch(config.databits)
 	{
 		case 5: options.c_cflag |= CS5; break;
@@ -196,6 +197,13 @@ bool SerialPort::setConfig(const SerialPortConfig & config)
         DBG("SerialPort::setConfig : can't set port settings");
         return false;
     }
+    
+    int new_baud = static_cast<int> (config.bps);
+    if (ioctl (portDescriptor, _IOW('T', 2, speed_t), &new_baud, 1) == -1) {
+        DBG("SerialPort::setConfig : can't set baud rate");
+        return false;
+    }
+    
 	return true;
 }
 bool SerialPort::getConfig(SerialPortConfig & config)

--- a/juce_serialport_Windows.cpp
+++ b/juce_serialport_Windows.cpp
@@ -9,6 +9,8 @@
 
 #if JUCE_WINDOWS
 
+using namespace juce;
+
 #include <windows.h>
 #include <stdio.h>
 


### PR DESCRIPTION
The standard method only works for a number of standard baud rates. This method works for any baud rate the driver accepts (tested at 31250bps).

Also adds `using namespace juce` for those of us who don't have that in the main juce header, and fixes some warnings under OS X / CLang.

NOTE that I'm using the C++11 `auto` keyword, so if there's desire to keep this C++03 compatible then the warning fixes in their current form should not be accepted.